### PR TITLE
Make Drogtor change player name cards

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.jvmargs=-Xmx1G
 # Mod Properties
 	maven_group = com.unascribed
 	archives_base_name = drogtor
-	version = 1.0.1
+	version = 1.1.0
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api

--- a/src/main/java/com/unascribed/drogtor/mixin/MixinPlayerListS2CPacket.java
+++ b/src/main/java/com/unascribed/drogtor/mixin/MixinPlayerListS2CPacket.java
@@ -1,0 +1,49 @@
+package com.unascribed.drogtor.mixin;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import com.mojang.authlib.GameProfile;
+import com.unascribed.drogtor.DrogtorPlayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+//I'm sorry.
+@Mixin(PlayerListS2CPacket.class)
+public class MixinPlayerListS2CPacket {
+	private Map<UUID, String> drogtor$playerIdMap = new HashMap<>();
+
+	@Inject(method = "<init>(Lnet/minecraft/network/packet/s2c/play/PlayerListS2CPacket$Action;[Lnet/minecraft/server/network/ServerPlayerEntity;)V", at = @At("RETURN"))
+	private void cachePlayerIdsArray(PlayerListS2CPacket.Action action, ServerPlayerEntity[] players, CallbackInfo info) {
+		for (ServerPlayerEntity player : players) {
+			if (player instanceof DrogtorPlayer && ((DrogtorPlayer) player).drogtor$isActive()) {
+				drogtor$playerIdMap.put(player.getUuid(), ((DrogtorPlayer) player).drogtor$getNickname());
+			}
+		}
+	}
+
+	@Inject(method = "<init>(Lnet/minecraft/network/packet/s2c/play/PlayerListS2CPacket$Action;Ljava/lang/Iterable;)V", at = @At("RETURN"))
+	private void cachePlayerIdsIterable(PlayerListS2CPacket.Action action, Iterable<ServerPlayerEntity> players, CallbackInfo info) {
+		for (ServerPlayerEntity player : players) {
+			if (player instanceof DrogtorPlayer && ((DrogtorPlayer) player).drogtor$isActive()) {
+				drogtor$playerIdMap.put(player.getUuid(), ((DrogtorPlayer) player).drogtor$getNickname());
+			}
+		}
+	}
+
+	/**
+	 * @author b0undarybreaker
+	 * @reason Replace the string ID in the sync packet with the Drogtor nickname
+	 */
+	@Redirect(method = "write", at = @At(value = "INVOKE", target = "Lcom/mojang/authlib/GameProfile;getName()Ljava/lang/String;"))
+	private String replacePlayerName(GameProfile profile) {
+		return drogtor$playerIdMap.getOrDefault(profile.getId(), profile.getName());
+	}
+}

--- a/src/main/resources/drogtor.mixins.json
+++ b/src/main/resources/drogtor.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinPlayerEntity",
+    "MixinPlayerListS2CPacket",
     "MixinServerPlayerEntity"
   ],
   "injectors": {


### PR DESCRIPTION
## The Problem

Drogtor works great for chat and the player list! However, it currently doesn't affect namecards, which are dictated by the `GameProfile` of each player. This sucks, because if you're using Drogtor to anonymize yourself on streams or videos, it's pretty much moot.

## The Solution

Packet Crimes! The `GameProfile` for *your* player is determined by AuthLib and Yggdrasil, but that doesn't matter because you can't see your own namecard. All other players' `GameProfile`s are sent from the server during the `PlayerListS2CPacket`, and more importantly, *the client does not validate them*. This means that, if we tamper with the player list packet, then it'll change! the namecards!

## The Catch

The one issue with this is that the `GameProfile` on a player entity is *final*. That means that, if you do `/nick` in front of someone else, your namecard will not change on their side until you unload and reload on their side - die, teleport, change dimensions, or disconnect. Commands will still also use profile names instead of namecard names.