### PR TITLE
Make Drogtor change player name cards (take 2)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.jvmargs=-Xmx1G
 # Mod Properties
 	maven_group = com.unascribed
 	archives_base_name = drogtor
-	version = 1.0.1
+	version = 1.1.0
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api

--- a/src/main/java/com/unascribed/drogtor/DrogtorMod.java
+++ b/src/main/java/com/unascribed/drogtor/DrogtorMod.java
@@ -23,14 +23,23 @@ public class DrogtorMod implements ModInitializer {
 							.executes((c) -> {
 								// replace § just in case
 								Text oldDn = c.getSource().getPlayer().getDisplayName();
-								((DrogtorPlayer)c.getSource().getPlayer()).drogtor$setNickname(c.getArgument("nick", String.class).replace("§", ""));
+								String newDn = c.getArgument("nick", String.class).replace("§", "");
+								((DrogtorPlayer) c.getSource().getPlayer()).drogtor$setNickname(newDn);
 								informDisplayName(c.getSource().getPlayer(), oldDn);
+								if (newDn.length() <= 16) {
+									((DrogtorPlayer) c.getSource().getPlayer()).drogtor$setNamecard(newDn);
+									informNamecard(c.getSource().getPlayer());
+								} else {
+									c.getSource().sendFeedback(new LiteralText("Your display name is longer than 16 characters! Please use `/namecard` to set your namecard due to vanilla limitations").formatted(Formatting.YELLOW), false);
+								}
 								return 1;
 							}))
 					.executes((c) -> {
 						Text oldDn = c.getSource().getPlayer().getDisplayName();
 						((DrogtorPlayer)c.getSource().getPlayer()).drogtor$setNickname(null);
+						((DrogtorPlayer)c.getSource().getPlayer()).drogtor$setNamecard(null);
 						informDisplayName(c.getSource().getPlayer(), oldDn);
+						informNamecard(c.getSource().getPlayer());
 						return 1;
 					}));
 			dispatcher.register(LiteralArgumentBuilder.<ServerCommandSource>literal("color")
@@ -47,6 +56,24 @@ public class DrogtorMod implements ModInitializer {
 						informDisplayName(c.getSource().getPlayer(), null);
 						return 1;
 					}));
+			dispatcher.register(LiteralArgumentBuilder.<ServerCommandSource>literal("namecard")
+					.then(RequiredArgumentBuilder.<ServerCommandSource, String>argument("namecard", StringArgumentType.greedyString())
+							.executes((c) -> {
+								// replace § just in case
+								String namecard = c.getArgument("namecard", String.class).replace("§", "");
+								if (namecard.length() > 16) {
+									c.getSource().sendError(new LiteralText("Namecard must be 16 or fewer characters due to vanilla limitations"));
+									return 0;
+								}
+								((DrogtorPlayer)c.getSource().getPlayer()).drogtor$setNamecard(namecard);
+								informNamecard(c.getSource().getPlayer());
+								return 1;
+							}))
+					.executes((c) -> {
+						((DrogtorPlayer)c.getSource().getPlayer()).drogtor$setNamecard(null);
+						informNamecard(c.getSource().getPlayer());
+						return 1;
+					}));
 		});
 	}
 
@@ -58,5 +85,9 @@ public class DrogtorMod implements ModInitializer {
 				if (spe != player) spe.sendMessage(t, false);
 			}
 		}
+	}
+
+	private void informNamecard(ServerPlayerEntity player) {
+		player.sendMessage(new LiteralText("Your namecard is now ").setStyle(Style.EMPTY.withColor(Formatting.YELLOW)).append(player.getDisplayName()), false);
 	}
 }

--- a/src/main/java/com/unascribed/drogtor/DrogtorPlayer.java
+++ b/src/main/java/com/unascribed/drogtor/DrogtorPlayer.java
@@ -7,11 +7,14 @@ import net.minecraft.util.Formatting;
 public interface DrogtorPlayer {
 
 	void drogtor$setNickname(@Nullable String nickname);
+	void drogtor$setNamecard(@Nullable String namecard);
 	void drogtor$setNameColor(@Nullable Formatting fmt);
 	
 	@Nullable String drogtor$getNickname();
+	@Nullable String drogtor$getNamecard();
 	@Nullable Formatting drogtor$getNameColor();
 	
 	boolean drogtor$isActive();
-	
+	boolean drogtor$isNamecardActive();
+
 }

--- a/src/main/java/com/unascribed/drogtor/mixin/MixinPlayerEntity.java
+++ b/src/main/java/com/unascribed/drogtor/mixin/MixinPlayerEntity.java
@@ -22,6 +22,8 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.world.World;
 
+import net.fabricmc.fabric.api.util.NbtType;
+
 @Mixin(PlayerEntity.class)
 public abstract class MixinPlayerEntity extends LivingEntity implements DrogtorPlayer {
 
@@ -30,12 +32,16 @@ public abstract class MixinPlayerEntity extends LivingEntity implements DrogtorP
 	}
 	
 	private String drogtor$nickname;
+	private String drogtor$namecard;
 	private Formatting drogtor$namecolor;
 	
 	@Inject(at = @At("TAIL"), method = "writeCustomDataToTag(Lnet/minecraft/nbt/CompoundTag;)V")
 	public void writeCustomDataToTag(CompoundTag tag, CallbackInfo ci) {
 		if (drogtor$nickname != null) {
 			tag.putString("drogtor:nickname", drogtor$nickname);
+		}
+		if (drogtor$namecard != null) {
+			tag.putString("drogtor:namecard", drogtor$namecard);
 		}
 		if (drogtor$namecolor != null) {
 			tag.putString("drogtor:namecolor", drogtor$namecolor.getName());
@@ -44,8 +50,9 @@ public abstract class MixinPlayerEntity extends LivingEntity implements DrogtorP
 	
 	@Inject(at = @At("TAIL"), method = "readCustomDataFromTag(Lnet/minecraft/nbt/CompoundTag;)V")
 	public void readCustomDataFromTag(CompoundTag tag, CallbackInfo ci) {
-		drogtor$nickname = tag.contains("drogtor:nickname") ? tag.getString("drogtor:nickname") : null;
-		drogtor$namecolor = tag.contains("drogtor:namecolor") ? Formatting.byName(tag.getString("drogtor:namecolor")) : null;
+		drogtor$nickname = tag.contains("drogtor:nickname", NbtType.STRING) ? tag.getString("drogtor:nickname") : null;
+		drogtor$namecard = tag.contains("drogtor:namecard", NbtType.STRING) ? tag.getString("drogtor:namecard") : null;
+		drogtor$namecolor = tag.contains("drogtor:namecolor", NbtType.STRING) ? Formatting.byName(tag.getString("drogtor:namecolor")) : null;
 	}
 	
 	@Inject(at = @At("HEAD"), method = "getName()Lnet/minecraft/text/Text;", cancellable = true)
@@ -63,6 +70,16 @@ public abstract class MixinPlayerEntity extends LivingEntity implements DrogtorP
 			mut.setStyle(mut.getStyle().withColor(drogtor$getNameColor()));
 		}
 	}
+
+	@Override
+	public @Nullable String drogtor$getNickname() {
+		return drogtor$nickname;
+	}
+
+	@Override
+	public @Nullable String drogtor$getNamecard() {
+		return drogtor$namecard;
+	}
 	
 	@Override
 	public @Nullable Formatting drogtor$getNameColor() {
@@ -70,16 +87,16 @@ public abstract class MixinPlayerEntity extends LivingEntity implements DrogtorP
 	}
 	
 	@Override
-	public @Nullable String drogtor$getNickname() {
-		return drogtor$nickname;
-	}
-	
-	@Override
 	public void drogtor$setNameColor(@Nullable Formatting fmt) {
 		drogtor$namecolor = fmt;
 		drogtor$updatePlayerListEntries();
 	}
-	
+
+	@Override
+	public void drogtor$setNamecard(String namecard) {
+		this.drogtor$namecard = namecard;
+	}
+
 	@Override
 	public void drogtor$setNickname(@Nullable String nickname) {
 		drogtor$nickname = nickname;
@@ -91,11 +108,15 @@ public abstract class MixinPlayerEntity extends LivingEntity implements DrogtorP
 		return drogtor$namecolor != null || drogtor$nickname != null;
 	}
 
+	@Override
+	public boolean drogtor$isNamecardActive() {
+		return drogtor$namecard != null;
+	}
+
 	private void drogtor$updatePlayerListEntries() {
 		if (((PlayerEntity)(Object)this) instanceof ServerPlayerEntity) {
 			world.getServer().getPlayerManager().sendToAll(new PlayerListS2CPacket(Action.UPDATE_DISPLAY_NAME, ((ServerPlayerEntity)(Object)this)));
 		}
 	}
-	
 
 }

--- a/src/main/java/com/unascribed/drogtor/mixin/MixinPlayerListS2CPacket.java
+++ b/src/main/java/com/unascribed/drogtor/mixin/MixinPlayerListS2CPacket.java
@@ -1,0 +1,49 @@
+package com.unascribed.drogtor.mixin;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import com.mojang.authlib.GameProfile;
+import com.unascribed.drogtor.DrogtorPlayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+//I'm sorry.
+@Mixin(PlayerListS2CPacket.class)
+public class MixinPlayerListS2CPacket {
+	private Map<UUID, String> drogtor$playerIdMap = new HashMap<>();
+
+	@Inject(method = "<init>(Lnet/minecraft/network/packet/s2c/play/PlayerListS2CPacket$Action;[Lnet/minecraft/server/network/ServerPlayerEntity;)V", at = @At("RETURN"))
+	private void cachePlayerIdsArray(PlayerListS2CPacket.Action action, ServerPlayerEntity[] players, CallbackInfo info) {
+		for (ServerPlayerEntity player : players) {
+			if (player instanceof DrogtorPlayer && ((DrogtorPlayer) player).drogtor$isActive()) {
+				drogtor$playerIdMap.put(player.getUuid(), ((DrogtorPlayer) player).drogtor$getNickname());
+			}
+		}
+	}
+
+	@Inject(method = "<init>(Lnet/minecraft/network/packet/s2c/play/PlayerListS2CPacket$Action;Ljava/lang/Iterable;)V", at = @At("RETURN"))
+	private void cachePlayerIdsIterable(PlayerListS2CPacket.Action action, Iterable<ServerPlayerEntity> players, CallbackInfo info) {
+		for (ServerPlayerEntity player : players) {
+			if (player instanceof DrogtorPlayer && ((DrogtorPlayer) player).drogtor$isActive()) {
+				drogtor$playerIdMap.put(player.getUuid(), ((DrogtorPlayer) player).drogtor$getNickname());
+			}
+		}
+	}
+
+	/**
+	 * @author b0undarybreaker
+	 * @reason Replace the string ID in the sync packet with the Drogtor nickname
+	 */
+	@Redirect(method = "write", at = @At(value = "INVOKE", target = "Lcom/mojang/authlib/GameProfile;getName()Ljava/lang/String;"))
+	private String replacePlayerName(GameProfile profile) {
+		return drogtor$playerIdMap.getOrDefault(profile.getId(), profile.getName());
+	}
+}

--- a/src/main/java/com/unascribed/drogtor/mixin/MixinPlayerListS2CPacket.java
+++ b/src/main/java/com/unascribed/drogtor/mixin/MixinPlayerListS2CPacket.java
@@ -18,13 +18,13 @@ import net.minecraft.server.network.ServerPlayerEntity;
 //I'm sorry.
 @Mixin(PlayerListS2CPacket.class)
 public class MixinPlayerListS2CPacket {
-	private Map<UUID, String> drogtor$playerIdMap = new HashMap<>();
+	private final Map<UUID, String> drogtor$playerIdMap = new HashMap<>();
 
 	@Inject(method = "<init>(Lnet/minecraft/network/packet/s2c/play/PlayerListS2CPacket$Action;[Lnet/minecraft/server/network/ServerPlayerEntity;)V", at = @At("RETURN"))
 	private void cachePlayerIdsArray(PlayerListS2CPacket.Action action, ServerPlayerEntity[] players, CallbackInfo info) {
 		for (ServerPlayerEntity player : players) {
-			if (player instanceof DrogtorPlayer && ((DrogtorPlayer) player).drogtor$isActive()) {
-				drogtor$playerIdMap.put(player.getUuid(), ((DrogtorPlayer) player).drogtor$getNickname());
+			if (player instanceof DrogtorPlayer && ((DrogtorPlayer) player).drogtor$isNamecardActive()) {
+				drogtor$playerIdMap.put(player.getUuid(), ((DrogtorPlayer) player).drogtor$getNamecard());
 			}
 		}
 	}
@@ -32,8 +32,8 @@ public class MixinPlayerListS2CPacket {
 	@Inject(method = "<init>(Lnet/minecraft/network/packet/s2c/play/PlayerListS2CPacket$Action;Ljava/lang/Iterable;)V", at = @At("RETURN"))
 	private void cachePlayerIdsIterable(PlayerListS2CPacket.Action action, Iterable<ServerPlayerEntity> players, CallbackInfo info) {
 		for (ServerPlayerEntity player : players) {
-			if (player instanceof DrogtorPlayer && ((DrogtorPlayer) player).drogtor$isActive()) {
-				drogtor$playerIdMap.put(player.getUuid(), ((DrogtorPlayer) player).drogtor$getNickname());
+			if (player instanceof DrogtorPlayer && ((DrogtorPlayer) player).drogtor$isNamecardActive()) {
+				drogtor$playerIdMap.put(player.getUuid(), ((DrogtorPlayer) player).drogtor$getNamecard());
 			}
 		}
 	}

--- a/src/main/java/com/unascribed/drogtor/mixin/MixinServerPlayerEntity.java
+++ b/src/main/java/com/unascribed/drogtor/mixin/MixinServerPlayerEntity.java
@@ -36,6 +36,7 @@ public abstract class MixinServerPlayerEntity extends PlayerEntity {
 				DrogtorPlayer us = (DrogtorPlayer)this;
 				DrogtorPlayer them = (DrogtorPlayer)oldPlayer;
 				us.drogtor$setNickname(them.drogtor$getNickname());
+				us.drogtor$setNamecard(them.drogtor$getNamecard());
 				us.drogtor$setNameColor(them.drogtor$getNameColor());
 			}
 		}

--- a/src/main/resources/drogtor.mixins.json
+++ b/src/main/resources/drogtor.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinPlayerEntity",
+    "MixinPlayerListS2CPacket",
     "MixinServerPlayerEntity"
   ],
   "injectors": {


### PR DESCRIPTION
## The Problem

Drogtor works great for chat and the player list! However, it currently doesn't affect namecards, which are dictated by the `GameProfile` of each player. This sucks, because if you're using Drogtor to anonymize yourself on streams or videos, it's pretty much moot.

## The Solution

Packet Crimes! The `GameProfile` for *your* player is determined by AuthLib and Yggdrasil, but that doesn't matter because you can't see your own namecard. All other players' `GameProfile`s are sent from the server during the `PlayerListS2CPacket`, and more importantly, *the client does not validate them*. This means that, if we tamper with the player list packet, then it'll change! the namecards!

## The Catch

The one issue with this is that the `GameProfile` on a player entity is *final*. That means that, if you do `/nick` in front of someone else, your namecard will not change on their side until you unload and reload on their side - die, teleport, change dimensions, or disconnect. Commands will still also use profile names instead of namecard names.

## The New Problem

It turns out that Minecraft usernames can't be longer than 16 characters! There's a new `drogtor$namecard` field which limits to 16 characters. If the nick set with `/nick` is 16 chars or shorter, it'll update the name card too. If not, you're gonna have to use `/namecard` to set a 16-char-or-shorter nick. It'll warn you if your nick is too long!